### PR TITLE
chapter/7 疑念をテストに翻訳する

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@
 - [ ]DollarとFrancの重複
 - [x]equalsの一般化
 - [x]timesの一般化
+- [ ]FrancとDollarを比較する

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ mod tests {
         assert!(!Dollar::new(5).equals(Dollar::new(6)));
         assert!(Franc::new(5).equals(Franc::new(5)));
         assert!(!Franc::new(5).equals(Franc::new(6)));
+        assert!(!Franc::new(5).equals(Dollar::new(5)));
     }
     #[test]
     fn test_franc_multiplication() {


### PR DESCRIPTION
注：
chapter/6にて、chapter/8でやるはずだったequalsメソッドの一般化をしているため、本チャプターのステップは飛ばさざるを得ない。
そのため、このバージョンでは、テストが失敗するが次回以降のチャプターで解消していく。