### PR TITLE
Chapter/9 歩幅の調整

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 - [ ]nullとの等価性比較
 - [ ]他のオブジェクトとの等価性比較
 - [x]5CHF * 2 = 10CHF
-- [ ]DollarとFrancの重複
+- [x]DollarとFrancの重複
 - [x]equalsの一般化
 - [x]timesの一般化
 - [ ]FrancとDollarを比較する
-- [ ]通貨の概念
+- [x]通貨の概念
 - [ ]testFrancMultiplicationを削除する？

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub struct Money {
-    amount: u32
+    amount: u32,
+    currency: &'static str
 }
 
 trait MoneyTrait {
@@ -14,28 +15,28 @@ pub struct Franc {
 
 impl Money {
     pub fn times (&self, multiplier: u32) -> Money {
-        Money {amount: self.amount * multiplier }
+        Money {
+            amount: &self.amount * multiplier,
+            currency: &self.currency
+        }
     }
     pub fn equals (&self, target: Money) -> bool {
         self.amount == target.amount
     }
     pub fn dollar (amount: u32) -> Money {
-        Money { amount: amount }
+        Money { 
+            amount: amount,
+            currency: "USD"
+        }
     }
     pub fn franc (amount: u32) -> Money {
-        Money { amount: amount }
+        Money { 
+            amount: amount,
+            currency: "CHF"
+        }
     }
-}
-
-impl MoneyTrait for Dollar {
-    fn new (amount: u32) -> Money {
-        Money { amount: amount }
-    }
-}
-
-impl Franc {
-    pub fn new (amount: u32) -> Money {
-        Money { amount: amount }
+    pub fn currency (&self) -> &'static str {
+        self.currency
     }
 }
 
@@ -61,5 +62,10 @@ mod tests {
         let five = Money::franc(5);
         assert!(Money::franc(10).equals(five.times(2)));
         assert!(Money::franc(15).equals(five.times(3)));
+    }
+    #[test]
+    fn test_currency() {
+        assert_eq!("USD", Money::dollar(1).currency());
+        assert_eq!("CHF", Money::franc(1).currency());
     }
 }


### PR DESCRIPTION
注
著書では、Doller・Francにそれぞれ実装して重複を削除してMoneyに引き上げるプロセスを踏んでいるが、
すでに共通化をしているため、そのプロセスは省略してMoneyに直接実装している。
その後のチャプターでDollar・Francは削除する予定だが、すでに使っていないためここで削除した。